### PR TITLE
Assumption Supported Trace Generation

### DIFF
--- a/examples/LilyDemo/AssumptionExample.txt
+++ b/examples/LilyDemo/AssumptionExample.txt
@@ -1,0 +1,3 @@
+This is an example of trace generation with an assumption 
+The lily demo has an assumption on the inputs G(cancel -> X(go || X go)). 
+Using the Assumption_Lily_Example.toml, a trace that follows the inputs can be generated.

--- a/examples/LilyDemo/AssumptionLilyExample.toml
+++ b/examples/LilyDemo/AssumptionLilyExample.toml
@@ -1,0 +1,16 @@
+[hoax]
+version = 1
+default-driver = "assumption"
+
+[[driver.assumption]]
+aps = ["cancel", "go"]
+assumption = "G(cancel -> X(go || X go))"
+assumption_ins = "cancel"
+assumption_outs = "go"
+bound = 20
+hoax_config = '../random.toml'
+[[driver.flip]]
+aps = ["grant", "req"]
+[runner]
+nondet = "random"
+bound = 10

--- a/examples/LilyDemo/README.md
+++ b/examples/LilyDemo/README.md
@@ -1,0 +1,3 @@
+# This is an example of trace generation with an assumption 
+The lily demo has an assumption on the inputs G(cancel -> X(go || X go)). 
+Using the Assumption_Lily_Example.toml, a trace that follows the inputs can be generated.

--- a/examples/LilyDemo/lilydemo04.hoa
+++ b/examples/LilyDemo/lilydemo04.hoa
@@ -1,0 +1,23 @@
+HOA: v1
+States: 4
+Start: 0
+AP: 4 "cancel" "grant" "req" "go"
+acc-name: all
+Acceptance: 0 t
+properties: trans-labels explicit-labels state-acc deterministic
+controllable-AP: 1
+--BODY--
+State: 0
+[!0&1] 1
+[0&1] 1
+State: 1
+[!0&!1] 2
+[0&!1] 3
+State: 2
+[0&1] 1
+[!0&!1] 0
+State: 3
+[0&1&3] 1
+[!0&!1&3] 0
+[!1&!3] 0
+--END--

--- a/examples/LilyDemo/lilydemo04.tlsf
+++ b/examples/LilyDemo/lilydemo04.tlsf
@@ -1,0 +1,40 @@
+INFO {
+  TITLE:       "Lily Demo V4"
+  DESCRIPTION: "One of the Lily demo files"
+  SEMANTICS:   Mealy
+  TARGET:      Mealy
+}
+
+MAIN {
+
+  INPUTS {
+    req;
+    cancel;
+    go;
+  }
+
+  OUTPUTS {
+    grant;
+  }
+
+  ASSUMPTIONS {
+    // A1 assume always(cancel -> next_e[1:2](go));
+    G (cancel -> X (go || X go));
+  } 
+
+  INVARIANTS {
+    // P1 always(req -> next_e[1:3](grant));
+    req -> X (grant || X (grant || X grant));
+
+    // P2 always(grant -> next(!grant));
+    grant -> X !grant;
+
+    // P3 always(cancel -> next((!grant) until! go));
+    cancel -> X (!grant U go);
+  }
+  
+}
+//#!SYNTCOMP
+//STATUS : realizable
+//REF_SIZE : 8
+//#.

--- a/hoax/drivers.py
+++ b/hoax/drivers.py
@@ -3,6 +3,10 @@ from abc import ABC, abstractmethod
 from io import TextIOWrapper
 from json import loads
 from random import choices
+import subprocess
+import re
+import os
+import tempfile
 
 log = logging.getLogger(__name__)
 
@@ -110,6 +114,139 @@ class SimpleTxtDriver(StreamDriver):
                 data.add(ap)
             line = self.stream.readline()
         return data
+
+import os
+import re
+import subprocess
+import tempfile
+from io import TextIOWrapper
+
+from hoax.drivers import StreamDriver, EndOfFiniteTrace
+
+
+class AssumptionTxtDriver(StreamDriver):
+    def __init__(self,
+                 aps: list[str],
+                 assumption: str = None,
+                 assumption_ins: str = None,
+                 assumption_outs: str = None,
+                 original_hoa: str = None,
+                 bound: int = 20,
+                 hoax_config: str = "./examples/random.toml",
+                 stream: TextIOWrapper = None,
+                 diff: bool = False):
+        self.assumption = assumption
+        self.ins = assumption_ins
+        self.outs = assumption_outs
+        self.original_hoa = original_hoa
+        self.bound = bound
+        self.hoax_config = hoax_config
+
+        # If no stream provided, generate one
+        if stream is None:
+            stream = self._generate_stream(aps)
+
+        super().__init__(aps=aps, stream=stream, diff=diff)
+
+    def _generate_stream(self, aps):
+        """
+        1. Build monitor HOA from assumption using Spot.
+        2. Run HOAX on monitor HOA to generate random trace.
+        3. Parse HOAX trace to StreamDriver format.
+        4. Return file stream to parsed trace.
+        """
+        import shutil
+        from pathlib import Path
+
+        # Step 1: Create temporary HOA file for assumption system
+        tmp_monitor = tempfile.NamedTemporaryFile(delete=False, suffix=".hoa")
+        monitor_name = tmp_monitor.name
+        tmp_monitor.close()
+
+        subprocess.run(
+            ["ltl2tgba", "-DM", self.assumption, "-o", monitor_name],
+            check=True,
+        )
+
+        # Step 2: Generate random trace from monitor HOA
+        tmp_trace = tempfile.NamedTemporaryFile(delete=False, suffix=".raw")
+        trace_name = tmp_trace.name
+        tmp_trace.close()
+
+        subprocess.run(
+            f"hoax {monitor_name} --config {self.hoax_config} > {trace_name}",
+            shell=True,
+            check=True,
+        )
+
+        # Step 3: Parse trace to SimpleTxtDriver format
+        reformatted = tempfile.NamedTemporaryFile(delete=False, suffix=".txt")
+        reformatted_name = reformatted.name
+        reformatted.close()
+        self._parse_trace(trace_name, aps, reformatted_name)
+
+        # --- NEW: save a permanent copy for inspection ---
+        dest_dir = Path("./generated_traces")
+        dest_dir.mkdir(exist_ok=True)
+        dest_path = dest_dir / f"assumption_trace_{os.getpid()}.txt"
+        shutil.copy(reformatted_name, dest_path)
+        print(f"[AssumptionTxtDriver] Saved generated trace to {dest_path}")
+
+        # Optional: clean up intermediate HOA and raw trace
+        os.unlink(monitor_name)
+        os.unlink(trace_name)
+
+        # Step 4: Return stream handle to reformatted file
+        return open(reformatted_name, "r")
+
+    def _parse_trace(self, trace_file: str, ap_list: list[str], out_path: str):
+        """
+        Convert HOAX raw output into StreamDriver (SimpleTxtDriver) format.
+        """
+        set_pat = re.compile(r"\{(.*?)\}")
+        with open(trace_file, "r") as infile, open(out_path, "w") as outfile:
+            for raw in infile:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                m = set_pat.search(raw)
+                if m:
+                    items = m.group(1).strip()
+                    if items == "":
+                        present = set()
+                    else:
+                        present = {
+                            tok.strip().strip("'\"")
+                            for tok in items.split(",")
+                            if tok.strip()
+                        }
+                else:
+                    present = set()
+
+                # One line per AP, blank line between timesteps
+                for ap in ap_list:
+                    outfile.write(f"{ap if ap in present else ''}\n")
+                outfile.write("\n")
+
+    def read_next(self):
+        """
+        Read one timestep of APs from the stream.
+        """
+        line = self.stream.readline()
+        if not line:
+            self.stream.close()
+            raise EndOfFiniteTrace(self.stream.name)
+
+        data = set()
+        while line:
+            if line == "\n":
+                return data
+            ap = line.strip()
+            if ap in self.aps:
+                data.add(ap)
+            line = self.stream.readline()
+        return data
+
 
 
 def handle(in_str: str) -> bool:

--- a/hoax/drivers.py
+++ b/hoax/drivers.py
@@ -7,6 +7,7 @@ import subprocess
 import re
 import os
 import tempfile
+from typing import Optional
 
 log = logging.getLogger(__name__)
 
@@ -127,13 +128,13 @@ from hoax.drivers import StreamDriver, EndOfFiniteTrace
 class AssumptionTxtDriver(StreamDriver):
     def __init__(self,
                  aps: list[str],
-                 assumption: str = None,
-                 assumption_ins: str = None,
-                 assumption_outs: str = None,
-                 original_hoa: str = None,
+                 assumption: Optional[str] = None,
+                 assumption_ins: Optional[str] = None,
+                 assumption_outs: Optional[str] = None,
+                 original_hoa: Optional[str] = None,
                  bound: int = 20,
                  hoax_config: str = "./examples/random.toml",
-                 stream: TextIOWrapper = None,
+                 stream: Optional[TextIOWrapper] = None,
                  diff: bool = False):
         self.assumption = assumption
         self.ins = assumption_ins
@@ -173,11 +174,13 @@ class AssumptionTxtDriver(StreamDriver):
         trace_name = tmp_trace.name
         tmp_trace.close()
 
+        # in AssumptionTxtDriver._generate_stream(...)
         subprocess.run(
-            f"hoax {monitor_name} --config {self.hoax_config} > {trace_name}",
+            f"hoax  {monitor_name} --config {self.hoax_config} > {trace_name}",
             shell=True,
             check=True,
         )
+
 
         # Step 3: Parse trace to SimpleTxtDriver format
         reformatted = tempfile.NamedTemporaryFile(delete=False, suffix=".txt")


### PR DESCRIPTION
Updates to the driver to support Assumption Based Trace generation. This takes in the assumption LTL formula alongside inputs which are critical to said assumption and generates a input.txt. It also takes in the rest of the atomic propositions and uses flip to generate them.